### PR TITLE
can only return from a function or sourced script

### DIFF
--- a/tmpl.sh
+++ b/tmpl.sh
@@ -14,7 +14,7 @@ vars=$(echo ${template} | grep -oE '\{\{[A-Za-z0-9_]+\}\}' | sort | uniq | sed -
 
 if [[ -z "$vars" ]]; then
     echo "Warning: No variable was found in $template, syntax is {{VAR}}" >&2
-    return 0
+    exit 0
 fi
 
 var_value() {


### PR DESCRIPTION
... but this is not the intended use. So the scripts does not exit and runs into the next error later.