### PR TITLE
warning wrongly triggered on vars with defaults

### DIFF
--- a/tmpl.sh
+++ b/tmpl.sh
@@ -11,7 +11,7 @@ fi
 
 template="${1}"
 
-if ! echo "$template" | grep -qoE '^\{\{[A-Za-z0-9_]+(=.+)?\}\}'; then
+if ! echo "$template" | grep -qoE '\{\{[A-Za-z0-9_]+(=.+)?\}\}'; then
     echo "Warning: No variable was found in $template, syntax is {{VAR}}" >&2
     exit 0
 fi

--- a/tmpl.sh
+++ b/tmpl.sh
@@ -11,7 +11,7 @@ fi
 
 template="${1}"
 
-if ! echo "$template" | grep -qoE '\{\{[A-Za-z0-9_]+(=.+)?\}\}'; then
+if ! echo "$template" | grep -qoP '\{\{[A-Za-z0-9_]+(=.+?)?\}\}'; then
     echo "Warning: No variable was found in $template, syntax is {{VAR}}" >&2
     exit 0
 fi
@@ -27,7 +27,7 @@ replaces=""
 # Reads default values defined as {{VAR=value}} and delete those lines
 # There are evaluated, so you can do {{PATH=$HOME}} or {{PATH=`pwd`}}
 # You can even reference variables defined in the template before
-defaults=$(echo "${template}" | grep -oE '^\{\{[A-Za-z0-9_]+=.+\}\}' | sed -e 's/^{{//' -e 's/}}$//')
+defaults=$(echo "${template}" | grep -oP '\{\{[A-Za-z0-9_]+=.+?\}\}' | sed -e 's/^{{//' -e 's/}}$//')
 for default in ${defaults}; do
     var=$(echo "${default}" | grep -oE "^[A-Za-z0-9_]+")
     current="$(var_value ${var})"

--- a/tmpl.sh
+++ b/tmpl.sh
@@ -10,12 +10,13 @@ if [[ -z "$1" ]]; then
 fi
 
 template="${1}"
-vars=$(echo ${template} | grep -oE '\{\{[A-Za-z0-9_]+\}\}' | sort | uniq | sed -e 's/^{{//' -e 's/}}$//')
 
-if [[ -z "$vars" ]]; then
+if ! echo "$template" | grep -qoE '^\{\{[A-Za-z0-9_]+(=.+)?\}\}'; then
     echo "Warning: No variable was found in $template, syntax is {{VAR}}" >&2
     exit 0
 fi
+
+vars=$(echo ${template} | grep -oE '\{\{[A-Za-z0-9_]+\}\}' | sort | uniq | sed -e 's/^{{//' -e 's/}}$//')
 
 var_value() {
     eval echo \$$1


### PR DESCRIPTION
example:

```
$ A=a B=b ./tmpl.sh '{{A=$B}}'
Warning: No variable was found in {{A=$B}}, syntax is {{VAR}}
```