### PR TITLE
support posix compliant shell

### DIFF
--- a/tmpl.sh
+++ b/tmpl.sh
@@ -5,11 +5,17 @@
 # ======================================
 
 if [[ -z "$1" ]]; then
-    echo "Usage: VAR=value $0 template" >&2
-    exit 1
+    template=$(cat; ret=$?; echo . && exit "$ret")
+    ret=$? template=${template%.}
+else
+    template="${1}"
 fi
 
-template="${1}"
+if [[ -z "$template" ]]; then
+    echo "Usage: VAR=value $0 template" >&2
+    echo "       VAR=value $0 template < /my/file" >&2
+    exit 1
+fi
 
 if ! echo "$template" | grep -qoE '^\{\{[A-Za-z0-9_]+(=.+)?\}\}'; then
     echo "Warning: No variable was found in $template, syntax is {{VAR}}" >&2

--- a/tmpl.sh
+++ b/tmpl.sh
@@ -11,7 +11,7 @@ fi
 
 template="${1}"
 
-if ! echo "$template" | grep -qoE '^\{\{[A-Za-z0-9_]+(=.+)?\}\}'; then
+if ! echo "$template" | grep -qoE '\{\{[A-Za-z0-9_]+(=.+)?\}\}'; then
     echo "Warning: No variable was found in $template, syntax is {{VAR}}" >&2
     exit 0
 fi

--- a/tmpl.sh
+++ b/tmpl.sh
@@ -11,7 +11,7 @@ fi
 
 template="${1}"
 
-if ! echo "$template" | grep -qoE '\{\{[A-Za-z0-9_]+(=.+)?\}\}'; then
+if ! echo "$template" | grep -qoP '\{\{[A-Za-z0-9_]+(=.+?)?\}\}'; then
     echo "Warning: No variable was found in $template, syntax is {{VAR}}" >&2
     exit 0
 fi
@@ -27,7 +27,7 @@ replaces=""
 # Reads default values defined as {{VAR=value}} and delete those lines
 # There are evaluated, so you can do {{PATH=$HOME}} or {{PATH=`pwd`}}
 # You can even reference variables defined in the template before
-defaults=$(echo "${template}" | grep -oE '^\{\{[A-Za-z0-9_]+=.+\}\}' | sed -e 's/^{{//' -e 's/}}$//')
+defaults=$(echo "${template}" | grep -oP '\{\{[A-Za-z0-9_]+=.+?\}\}' | sed -e 's/^{{//' -e 's/}}$//')
 for default in ${defaults}; do
     var=$(echo "${default}" | grep -oE "^[A-Za-z0-9_]+")
     current="$(var_value ${var})"

--- a/tmpl.sh
+++ b/tmpl.sh
@@ -1,17 +1,17 @@
-#!/bin/bash
+#!/bin/sh
 
 # ======================================
-# simple templating engine for bash
+# simple templating engine for sh
 # ======================================
 
-if [[ -z "$1" ]]; then
+if [ -z "$1" ]; then
     template=$(cat; ret=$?; echo . && exit "$ret")
     ret=$? template=${template%.}
 else
     template="${1}"
 fi
 
-if [[ -z "$template" ]]; then
+if [ -z "$template" ]; then
     echo "Usage: VAR=value $0 template" >&2
     echo "       VAR=value $0 template < /my/file" >&2
     exit 1
@@ -39,7 +39,7 @@ for default in ${defaults}; do
     current="$(var_value ${var})"
 
     # Replace only if var is not set
-    if [[ -z "${current}" ]]; then
+    if [ -z "${current}" ]; then
         eval ${default}
     fi
 
@@ -54,7 +54,7 @@ vars=$(echo ${vars} | sort | uniq)
 # Replace all {{VAR}} by $VAR value
 for var in ${vars}; do
     value="$(var_value ${var})"
-    if [[ -z "${value}" ]]; then
+    if [ -z "${value}" ]; then
         echo "Warning: ${var} is not defined and no default is set, replacing by empty" >&2
     fi
 

--- a/tmpl.sh
+++ b/tmpl.sh
@@ -10,12 +10,13 @@ if [[ -z "$1" ]]; then
 fi
 
 template="${1}"
-vars=$(echo ${template} | grep -oE '\{\{[A-Za-z0-9_]+\}\}' | sort | uniq | sed -e 's/^{{//' -e 's/}}$//')
 
-if [[ -z "$vars" ]]; then
+if ! echo "$template" | grep -qoE '^\{\{[A-Za-z0-9_]+(=.+)?\}\}'; then
     echo "Warning: No variable was found in $template, syntax is {{VAR}}" >&2
     exit 0
 fi
+
+vars=$(echo ${template} | grep -oE '\{\{[A-Za-z0-9_]+\}\}' | sort | uniq | sed -e 's/^{{//' -e 's/}}$//')
 
 var_value() {
     eval echo \$$1


### PR DESCRIPTION
before:
```
$ A=a dash ./tmpl.sh {{A}}
./tmpl.sh: 7: [[: not found
./tmpl.sh: 14: [[: not found
./tmpl.sh: 57: [[: not found
a
```

after:
```
$ A=a dash ./tmpl.sh {{A}}
a
```